### PR TITLE
Add --flush option, which will ensure latest changes are pulled in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ In your project root, create `elder2fs.yml`. Here is an example:
 Once configured, you can run elder2fs by:
 
 	vendor/bin/elder2fs
+
+If it's human operated, you might want to ensure caches are flushed, especially if you have just committed some changes:
+
+	vendor/bin/elder2fs --flush

--- a/bin/elder2fs
+++ b/bin/elder2fs
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
 
+use Elder2Fs\Middleware;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
 
@@ -53,12 +54,17 @@ $root->walk('Elder2Fs\Dir', function ($dir) use ($log) {
     }
 });
 
+$options = getopt('', ['flush']);
+
 $handlerStack = \GuzzleHttp\HandlerStack::create(new \GuzzleHttp\Handler\CurlHandler());
 $handlerStack->push(
     \GuzzleHttp\Middleware::retry(
         \Elder2Fs\Retry::create_decider($log)
     )
 );
+if (isset($options['flush'])) {
+    $handlerStack->push(Middleware::flush());
+}
 $client = new \GuzzleHttp\Client([
     'handler' => $handlerStack,
     'base_uri' => $config->getService(),

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Elder2Fs;
+
+use function GuzzleHttp\Psr7\stream_for;
+use Psr\Http\Message\RequestInterface;
+
+class Middleware
+{
+    public static function flush()
+    {
+        $token = sha1(getenv('PATH') . getenv('PWD') . getenv('USER') . bin2hex(openssl_random_pseudo_bytes(20)));
+
+        return function (callable $handler) use ($token) {
+            return function (RequestInterface $request, array $options) use ($handler, $token) {
+                if (in_array('application/json', $request->getHeader('Content-Type'))) {
+                    $b = json_decode($request->getBody(), true);
+                    $b['flushToken'] = $token;
+                    $request = $request->withBody(stream_for(json_encode($b)));
+                }
+                return $handler($request, $options);
+            };
+        };
+    }
+}


### PR DESCRIPTION
Good for human-operated elder2fs runs.